### PR TITLE
Add `bookmarks/get_text`

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ client.bookmarks.star(BOOKMARK_ID)      : Promise
 client.bookmarks.unstar(BOOKMARK_ID)    : Promise
 client.bookmarks.archive(BOOKMARK_ID)   : Promise
 client.bookmarks.unarchive(BOOKMARK_ID) : Promise
+client.bookmarks.get_text(BOOKMARK_ID)  : Promise
 ```
 
 ### Folder management

--- a/lib/index.js
+++ b/lib/index.js
@@ -99,7 +99,7 @@ Instapaper.prototype.request = function(endpoint, body, callback) {
                 return this.POST(opts);
               })
               .spread(function(response, request) {
-                return JSON.parse(response);
+                return response.indexOf('<html>') === 0 ? response : JSON.parse(response);
               })
               .catch(function(err) {
                 try {
@@ -145,6 +145,10 @@ Bookmarks.prototype.archive = function(id, callback) {
 
 Bookmarks.prototype.unarchive = function(id, callback) {
   return this.client.request('/bookmarks/unarchive', { bookmark_id : id }, callback);
+};
+
+Bookmarks.prototype.get_text = function(id, callback) {
+  return this.client.request('/bookmarks/get_text', { bookmark_id : id }, callback);
 };
 
 /*


### PR DESCRIPTION
Thanks for your awesome work!

I needed to get the text/html of a bookmark, so I added a quick handler for the `bookmarks/get_text` method. 

As the response of `bookmarks/get_text` is HTML and not JSON there needs to be a custom response handling. Of course this is done in a dirty way, but it fits my needs for now. I'm open for a better solution ;)
