### PR TITLE
Upgrade Lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "bluebird": "^2.9.25",
     "custom-error": "^0.2.1",
-    "lodash": "^3.9.3",
+    "lodash": "^4.17.21",
     "mashape-oauth": "^0.1.71",
     "request": "^2.55.0",
     "winston": "^1.0.0"


### PR DESCRIPTION
When pulling down node-instapaper I noticed the following error with `npm audit`

```
added 65 packages from 83 contributors and audited 66 packages in 4.532s

3 packages are looking for funding
  run `npm fund` for details

found 7 vulnerabilities (1 low, 2 moderate, 3 high, 1 critical)
  run `npm audit fix` to fix them, or `npm audit` for details
```

The current version of `lodash` was to blame for all the vulnerabilities. Running `npm audit fix --force` updated `lodash` to fix the vulnerabilities (`--force` due to a breaking change). Running a quick grep it appears that `lodash` is only used for `merge` a single set of options, and should not be affected by the breaking change 🙂 

```
~/repos/node-instapaper patch-vulns
❯ grep -r --exclude-dir="node_modules" lodash ./
.//package.json:    "lodash": "^4.17.21",
.//lib/index.js:var lodash  = require('lodash');
.//lib/index.js:  this.opts = lodash.merge({}, DEFAULTS, opts);
```

A fresh run of `npm audit` confirms this:

```
~/repos/node-instapaper patch-vulns*
❯ npm audit

                       === npm audit security report ===

found 0 vulnerabilities
 in 58 scanned packages
```